### PR TITLE
Deleted LibraryExistByAddressException useless methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,3 +55,6 @@ dependencyManagement{
 test {
     useJUnitPlatform()
 }
+tasks.test{
+    jvmArgs("--add-opens", "java.base/java.time=ALL-UNNAMED")
+}

--- a/src/main/java/server/library/exception/LibraryExistByAddressException.java
+++ b/src/main/java/server/library/exception/LibraryExistByAddressException.java
@@ -8,12 +8,4 @@ public class LibraryExistByAddressException extends RuntimeException {
     public LibraryExistByAddressException(String message) {
         super("Library with "+message+" already exists!");
     }
-
-    public LibraryExistByAddressException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public LibraryExistByAddressException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/src/test/java/server/library/controller/SpringTestConfig.java
+++ b/src/test/java/server/library/controller/SpringTestConfig.java
@@ -7,8 +7,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 import server.library.domain.Book;
 
 import javax.persistence.EntityManager;
@@ -19,7 +27,24 @@ import java.util.List;
 @Sql(value = "/test/migration/AFTER_TESTS.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
 public abstract class SpringTestConfig {
+
+    @Container
+    public static PostgreSQLContainer postgreSQLContainer=new PostgreSQLContainer("postgres:14.1")
+            .withDatabaseName("integreation-tests-db")
+            .withUsername("sa")
+            .withPassword("sa");
+    static class Initializer
+            implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+            TestPropertyValues.of(
+                    "spring.datasource.url=" + postgreSQLContainer.getJdbcUrl(),
+                    "spring.datasource.username=" + postgreSQLContainer.getUsername(),
+                    "spring.datasource.password=" + postgreSQLContainer.getPassword()
+            ).applyTo(configurableApplicationContext.getEnvironment());
+        }
+    }
 
     @Autowired
     protected MockMvc mvc;

--- a/src/test/resources/test/migration/INSERT_BOOKS.sql
+++ b/src/test/resources/test/migration/INSERT_BOOKS.sql
@@ -1,3 +1,5 @@
+alter sequence book_id_seq restart with 4;
+
 insert into book(id,name,library_id,description,is_bestseller) values (1,'Test',1,'Just best book',true);
 insert into book(id,name,library_id,description,is_bestseller) values (2,'Worst Book',1,'Just worst book',false);
 insert into book(id,name,library_id,description,is_bestseller) values (3,'Best Book',2,'Just best book',true);
@@ -8,4 +10,3 @@ insert into authors(book_id, authors) VALUES (2,'Mi');
 insert into authors(book_id, authors) VALUES (3,'Li');
 insert into publishers(book_id, publishers) VALUES (1,'ATM');
 
-alter sequence book_id_seq restart with 4;


### PR DESCRIPTION
Deleted useless methods in LibraryException cause this exception is single in hierarchy. That`s why other exception can`t be throw